### PR TITLE
General code improvements

### DIFF
--- a/jquery.djax.js
+++ b/jquery.djax.js
@@ -130,8 +130,7 @@
 
 					var newBlock = $(this),
 					    id = '#' + $(this).attr('id'),
-					    $previousSibling,
-						lastBlock;
+					    $previousSibling;
 
 					// If there is a new page block without an equivalent block
 					// in the old page, we need to find out where to insert it
@@ -148,8 +147,6 @@
 							newBlock.prependTo('#' + newBlock.parent().attr('id'));
 						}
 					}
-
-					lastBlock = blocks.filter(id);
 
 				});
 

--- a/jquery.djax.js
+++ b/jquery.djax.js
@@ -17,6 +17,7 @@
 *   Brian Zeligson github @beezee
 *
 */
+
 (function ($, exports) {
 	'use strict';
 
@@ -87,7 +88,7 @@
 			// Get the new page
 			$.get(url, function (response) {
 				if (url !== self.reqUrl) {
-					self.navigate(self.reqUrl);
+					self.navigate(self.reqUrl, false);
 					return true;
 				}
 
@@ -189,7 +190,7 @@
 			self.djaxing = false;
 			if (event.originalEvent.state) {
 				self.reqUrl = event.originalEvent.state.url;
-				self.navigate(event.originalEvent.state.url);
+				self.navigate(event.originalEvent.state.url, false);
 			}
 		});
 

--- a/jquery.djax.js
+++ b/jquery.djax.js
@@ -1,7 +1,7 @@
 /*
 * jQuery djax
 *
-* @version v0.11
+* @version v0.12
 *
 * Copyright 2012, Brian Zeligson
 * Released under the MIT license.
@@ -18,7 +18,7 @@
 *
 */
 (function ($, exports) {
-    'use strict';
+	'use strict';
 
 	$.fn.djax = function (selector, exceptions) {
 
@@ -29,7 +29,18 @@
 
 		var self = this,
 		    blockSelector = selector,
-		    excludes = (exceptions && exceptions.length) ? exceptions : [];
+		    excludes = (exceptions && exceptions.length) ? exceptions : [],
+			djaxing = false;
+
+		// Ensure that the history is correct when going from 2nd page to 1st
+		window.history.replaceState(
+			{
+				'url' : window.location.href,
+				'title' : $('title').text()
+			},
+			$('title').text(),
+			window.location.href
+		);
 
 		// Exclude the link exceptions
 		self.attachClick = function (el, e) {
@@ -46,7 +57,7 @@
 				}
 			});
 
-			if (exception) {
+			if (exception || self.djaxing) {
 				return $(el);
 			}
 
@@ -61,6 +72,8 @@
 		self.navigate = function (url, add) {
 
 			var blocks = $(blockSelector);
+
+			self.djaxing = true;
 
 			// Get the new page
 			$.get(url, function (response) {
@@ -148,6 +161,7 @@
 						}]
 					);
 					self.triggered = true;
+					self.djaxing = false;
 				}
 			});
 		}; /* End self.navigate */
@@ -165,6 +179,7 @@
 		// On new page load
 		$(window).bind('popstate', function (event) {
 			self.triggered = false;
+			self.djaxing = false;
 			if (event.originalEvent.state) {
 				self.reqUrl = event.originalEvent.state.url;
 				self.navigate(event.originalEvent.state.url);

--- a/jquery.djax.js
+++ b/jquery.djax.js
@@ -97,7 +97,7 @@
 				if (add) {
 					window.history.pushState(
 						{
-							'url': url,
+							'url' : url,
 							'title' : $(result).filter('title').text()
 						},
 						$(result).filter('title').text(),
@@ -155,7 +155,7 @@
 				// Only add a class to internal links
 				$('a').filter(function () {
 					return this.hostname === location.hostname;
-				}).addClass('dJAX_internal').on('click', function (e) {
+				}).addClass('dJAX_internal').on('click.djax', function (e) {
 					return self.attachClick(this, e);
 				});
 
@@ -164,7 +164,7 @@
 					$(window).trigger(
 						'djaxLoad',
 						[{
-							'url': url,
+							'url' : url,
 							'title' : $(result).filter('title').text(),
 							'response' : response
 						}]
@@ -181,7 +181,7 @@
 		}).addClass('dJAX_internal');
 
 
-		$('a.dJAX_internal').on('click', function (e) {
+		$('a.dJAX_internal').on('click.djax', function (e) {
 			return self.attachClick(this, e);
 		});
 

--- a/jquery.djax.js
+++ b/jquery.djax.js
@@ -43,16 +43,16 @@
 		);
 
 		// Exclude the link exceptions
-		self.attachClick = function (el, e) {
+		self.attachClick = function (element, event) {
 
-			var link = $(el),
+			var link = $(element),
 				exception = false;
 
-			$.each(excludes, function (k, x) {
-				if (link.attr('href').indexOf(x) !== -1) {
+			$.each(excludes, function (index, exclusion) {
+				if (link.attr('href').indexOf(exclusion) !== -1) {
 					exception = true;
 				}
-				if (window.location.href.indexOf(x) !== -1) {
+				if (window.location.href.indexOf(exclusion) !== -1) {
 					exception = true;
 				}
 			});
@@ -60,15 +60,15 @@
 			// If the link is one of the exceptions, return early so that
 			// the link can be clicked and a full page load as normal
 			if (exception) {
-				return $(el);
+				return $(element);
 			}
 
 			// From this point on, we handle the behaviour
-			e.preventDefault();
+			event.preventDefault();
 
 			// If we're already doing djaxing, return now and silently fail
 			if (self.djaxing) {
-				return $(el);
+				return $(element);
 			}
 
 			$(window).trigger('djaxClick');
@@ -153,8 +153,8 @@
 				// Only add a class to internal links
 				$('a').filter(function () {
 					return this.hostname === location.hostname;
-				}).addClass('dJAX_internal').on('click.djax', function (e) {
-					return self.attachClick(this, e);
+				}).addClass('dJAX_internal').on('click.djax', function (event) {
+					return self.attachClick(this, event);
 				});
 
 				// Trigger djaxLoad event as a pseudo ready()
@@ -179,8 +179,8 @@
 		}).addClass('dJAX_internal');
 
 
-		$('a.dJAX_internal').on('click.djax', function (e) {
-			return self.attachClick(this, e);
+		$('a.dJAX_internal').on('click.djax', function (event) {
+			return self.attachClick(this, event);
 		});
 
 		// On new page load

--- a/jquery.djax.js
+++ b/jquery.djax.js
@@ -57,11 +57,20 @@
 				}
 			});
 
-			if (exception || self.djaxing) {
+			// If the link is one of the exceptions, return early so that
+			// the link can be clicked and a full page load as normal
+			if (exception) {
 				return $(el);
 			}
 
+			// From this point on, we handle the behaviour
 			e.preventDefault();
+
+			// If we're already doing djaxing, return now and silently fail
+			if (self.djaxing) {
+				return $(el);
+			}
+
 			$(window).trigger('djaxClick');
 			self.reqUrl = link.attr('href');
 			self.triggered = false;

--- a/jquery.djax.js
+++ b/jquery.djax.js
@@ -18,6 +18,17 @@
 *
 */
 
+/*jslint browser: true, indent: 4, maxerr: 50, sub: true */
+/*jshint bitwise:true, curly:true, eqeqeq:true, forin:true, immed:true, latedef:true, noarg:true, noempty:true, nomen:true, nonew:true, onevar:true, plusplus:true, regexp:true, smarttabs:true, strict:true, trailing:true, undef:true, white:true, browser:true, jquery:true, indent:4, maxerr:50, */
+/*global jQuery */
+
+// ==ClosureCompiler==
+// @compilation_level ADVANCED_OPTIMIZATIONS
+// @output_file_name jquery.djax.js
+// @externs_url http://closure-compiler.googlecode.com/svn/trunk/contrib/externs/jquery-1.7.js
+// ==/ClosureCompiler==
+// http://closure-compiler.appspot.com/home
+
 (function ($, exports) {
 	'use strict';
 

--- a/jquery.djax.js
+++ b/jquery.djax.js
@@ -1,73 +1,176 @@
-(function($, exports) {
-    
-    $.fn.djax = function(selector, exceptions) {
-        if (!history.pushState) return $(this);
-        
-        var self = this;
-                
-        window.history.replaceState({'url': window.location.href, 'title' : $('title').text()}, $('title').text(), window.location.href);
-        
-        var blockSelector = selector;
-        
-        var excludes = (exceptions && exceptions.length) ? exceptions : [];
-        
-        self.navigate = function(url, add) {
-            var blocks = $(blockSelector);
-             $.get(url, function(response) {
-              if (url != self.reqUrl) { self.navigate(self.reqUrl); return true; }
-              var result = $('"'+response+'"');
-              if (add) window.history.pushState({'url': url, 'title' : $(result).filter('title').text()}, $(result).filter('title').text(), url);
-              $('title').text($(result).filter('title').text());
-                  var newBlocks = [];
-                  var newBlocks = $(result).find(blockSelector);
-                  blocks.each(function() {
-                      var id = '"#'+$(this).attr('id')+'"';
-                      var newBlock = newBlocks.filter(id);
-                      var block = $(this);
-                      if (newBlock.length) {
-                          if (block.html() != newBlock.html()) block.replaceWith(newBlock);
-                      } else block.remove();
-                  });
-                  $.each(newBlocks, function() {
-                     var newBlock = $(this);
-                     var id = '#'+$(this).attr('id');
-                     if (!$(id).length) {
-                          var before = $(result).find(id).prev();
-                          if (before.length) { var beforeID = '#'+ before.attr('id'); newBlock.insertAfter(beforeID); }
-                          else { var parentID = '#' + newBlock.parent().attr('id'); newBlock.prependTo(parentID); }
-                     }
-                      lastBlock = blocks.filter(id);
-                  });
-                  $('a').filter(function() { return this.hostname == location.hostname; }).addClass('dJAX_internal');
-                  if (!self.triggered) $(window).trigger('djaxLoad', [{'url': url, 'title' : $(result).filter('title').text()}]);
-                  self.triggered = true;
-             });
-          }
-    
-        $(this).find('a').filter(function() { return this.hostname == location.hostname; }).addClass('dJAX_internal');
-        
-        
-        $('a.dJAX_internal').live('click', function(e) {
-            var link = $(this);
-           var exception = false;
-           $.each(excludes, function(k, x) {
-             if (link.attr('href').indexOf(x) != -1) exception = true;
-             if (window.location.href.indexOf(x) != -1) exception = true;
-           });
-           if (exception) return $(this);
-           e.preventDefault();
-           $(window).trigger('djaxClick');
-           self.reqUrl = link.attr('href');
-           self.triggered = false;
-           self.navigate(link.attr('href'), true);
-        });
-        
-        $(window).bind('popstate', function(event){
-            self.triggered = false;
-            self.reqUrl = event.originalEvent.state.url;
-            self.navigate(event.originalEvent.state.url);
-        });
-        
-    }
-    
-})(jQuery, window);
+/*
+* jQuery djax
+*
+* @version v0.11
+*
+* Copyright 2012, Brian Zeligson
+* Released under the MIT license.
+* http://www.opensource.org/licenses/mit-license.php
+*
+* Homepage:
+*   http://beezee.github.com/djax.html
+*
+* Authors:
+*   Brian Zeligson
+*
+* Maintainer:
+*   Brian Zeligson github @beezee
+*
+*/
+(function ($, exports) {
+    'use strict';
+
+	$.fn.djax = function (selector, exceptions) {
+
+		// If browser doesn't support pushState, abort now
+		if (!history.pushState) {
+			return $(this);
+		}
+
+		var self = this,
+		    blockSelector = selector,
+		    excludes = (exceptions && exceptions.length) ? exceptions : [];
+
+		// Exclude the link exceptions
+		self.attachClick = function (el, e) {
+
+			var link = $(el),
+				exception = false;
+
+			$.each(excludes, function (k, x) {
+				if (link.attr('href').indexOf(x) !== -1) {
+					exception = true;
+				}
+				if (window.location.href.indexOf(x) !== -1) {
+					exception = true;
+				}
+			});
+
+			if (exception) {
+				return $(el);
+			}
+
+			e.preventDefault();
+			$(window).trigger('djaxClick');
+			self.reqUrl = link.attr('href');
+			self.triggered = false;
+			self.navigate(link.attr('href'), true);
+		};
+
+		// Handle the navigation
+		self.navigate = function (url, add) {
+
+			var blocks = $(blockSelector);
+
+			// Get the new page
+			$.get(url, function (response) {
+				if (url !== self.reqUrl) {
+					self.navigate(self.reqUrl);
+					return true;
+				}
+
+				var result = $('"' + response + '"'),
+				    newBlocks = $(result).find(blockSelector);
+
+				if (add) {
+					window.history.pushState(
+						{
+							'url': url,
+							'title' : $(result).filter('title').text()
+						},
+						$(result).filter('title').text(),
+						url
+					);
+				}
+
+				// Set page title as new page title
+				$('title').text($(result).filter('title').text());
+
+				// Loop through each block and find new page equivalent
+				blocks.each(function () {
+
+					var id = '"#' + $(this).attr('id') + '"',
+					    newBlock = newBlocks.filter(id),
+					    block = $(this);
+
+					if (newBlock.length) {
+						if (block.html() !== newBlock.html()) {
+							block.replaceWith(newBlock);
+						}
+					} else {
+						block.remove();
+					}
+
+				});
+
+				// Loop through new page blocks and add in as needed
+				$.each(newBlocks, function () {
+
+					var newBlock = $(this),
+					    id = '#' + $(this).attr('id'),
+					    before,
+					    beforeID,
+					    parentID,
+						lastBlock;
+
+					if (!$(id).length) {
+
+						before = $(result).find(id).prev();
+
+						if (before.length) {
+							beforeID = '#' + before.attr('id');
+							newBlock.insertAfter(beforeID);
+						} else {
+							parentID = '#' + newBlock.parent().attr('id');
+							newBlock.prependTo(parentID);
+						}
+					}
+
+					lastBlock = blocks.filter(id);
+
+				});
+
+				// Only add a class to internal links
+				$('a').filter(function () {
+					return this.hostname === location.hostname;
+				}).addClass('dJAX_internal').on('click', function (e) {
+					return self.attachClick(this, e);
+				});
+
+				// Trigger djaxLoad event as a pseudo ready()
+				if (!self.triggered) {
+					$(window).trigger(
+						'djaxLoad',
+						[{
+							'url': url,
+							'title' : $(result).filter('title').text(),
+							'response' : response
+						}]
+					);
+					self.triggered = true;
+				}
+			});
+		}; /* End self.navigate */
+
+		// Only add a class to internal links
+		$(this).find('a').filter(function () {
+			return this.hostname === location.hostname;
+		}).addClass('dJAX_internal');
+
+
+		$('a.dJAX_internal').on('click', function (e) {
+			return self.attachClick(this, e);
+		});
+
+		// On new page load
+		$(window).bind('popstate', function (event) {
+			self.triggered = false;
+			if (event.originalEvent.state) {
+				self.reqUrl = event.originalEvent.state.url;
+				self.navigate(event.originalEvent.state.url);
+			}
+		});
+
+	};
+
+}(jQuery, window));

--- a/jquery.djax.js
+++ b/jquery.djax.js
@@ -130,21 +130,22 @@
 
 					var newBlock = $(this),
 					    id = '#' + $(this).attr('id'),
-					    before,
-					    beforeID,
-					    parentID,
+					    $previousSibling,
 						lastBlock;
 
+					// If there is a new page block without an equivalent block
+					// in the old page, we need to find out where to insert it
 					if (!$(id).length) {
 
-						before = $(result).find(id).prev();
+						// Find the previous sibling
+						$previousSibling = $(result).find(id).prev();
 
-						if (before.length) {
-							beforeID = '#' + before.attr('id');
-							newBlock.insertAfter(beforeID);
+						if ($previousSibling.length) {
+							// Insert after the previous element
+							newBlock.insertAfter('#' + $previousSibling.attr('id'));
 						} else {
-							parentID = '#' + newBlock.parent().attr('id');
-							newBlock.prependTo(parentID);
+							// There's no previous sibling, so prepend to parent instead
+							newBlock.prependTo('#' + newBlock.parent().attr('id'));
 						}
 					}
 


### PR DESCRIPTION
Formats code to match with jshints defaults. Some people are fussy and would do this anyway (and those that aren't bothered, aren't bothered), so for the sake of a few extra braces and whitespace, it would be better to have it completed in core. The JS can always be minified by those that want to save a few extra bytes.

Adds some basic documentation - mostly comments for each function or block of code.

Removes replaceState bit of code, since it seemed to be replacing the last history item with exactly the same details. Not sure if I misunderstood why this was present in the first place.

Removes duplicate `var newBlocks = ...` line.

Incorporates the changes made in #9.

Adds 'use strict'; statement.

Obviously, please test on your own setup before merging.

NOT DONE:
Bumped version
Added me as a contributor ;-)
